### PR TITLE
Fix old package scanning

### DIFF
--- a/app/lib/stats/messages.js
+++ b/app/lib/stats/messages.js
@@ -8,6 +8,12 @@ export const collectMessages = async (files) => {
   const dmChannels = [];
   const guildChannels = [];
 
+  let oldPackage = false;
+  const file = files.find((f) => /messages\/([0-9]{16,32})\/$/.test(f.name));
+  if (file) {
+    oldPackage = true;
+  }
+
   await Promise.all(Object.entries(messageIndex).map(async ([channelID, description]) => {
     const channelData = {
       id: channelID,
@@ -15,7 +21,7 @@ export const collectMessages = async (files) => {
     };
 
     // fetch the channel metadata
-    const channelMetadata = JSON.parse(await readFile(files, `messages/c${channelData.id}/channel.json`));
+    const channelMetadata = JSON.parse(await readFile(files, `messages/${oldPackage ? '' : 'c'}${channelData.id}/channel.json`));
     channelData.type = channelMetadata.type;
 
     // fetch the channel messages

--- a/app/lib/stats/messages.js
+++ b/app/lib/stats/messages.js
@@ -12,6 +12,7 @@ export const collectMessages = async (files) => {
   const file = files.find((f) => /messages\/([0-9]{16,32})\/$/.test(f.name));
   if (file) {
     oldPackage = true;
+    console.debug('Old messages package detected');
   }
 
   await Promise.all(Object.entries(messageIndex).map(async ([channelID, description]) => {
@@ -25,7 +26,7 @@ export const collectMessages = async (files) => {
     channelData.type = channelMetadata.type;
 
     // fetch the channel messages
-    const rawMessages = await readFile(files, `messages/c${channelData.id}/messages.csv`);
+    const rawMessages = await readFile(files, `messages/${oldPackage ? '' : 'c'}${channelData.id}/messages.csv`);
     const messageData = parseCSV(rawMessages, {
       header: true,
       newline: ',\r',

--- a/app/lib/stats/stats.js
+++ b/app/lib/stats/stats.js
@@ -48,11 +48,20 @@ const collectGlobalStats = async (files, { dmChannels, guildChannels }, analytic
     return payments.map((p) => p.amount).reduce((sum, amount) => sum + amount, 0);
   };
 
+  let darkModeEnabled = false;
+  let darkModeSetting = userData.settings?.settings?.appearance?.theme;
+  if (!darkModeSetting) {
+    darkModeSetting = userData.settings.theme;
+  }
+  if (darkModeSetting.toLowerCase() === 'dark') {
+    darkModeEnabled = true;
+  }
+
   let stats = {
     // account stats
     userID: userData.id,
     userTag: `${userData.username}#${userData.discriminator}`,
-    darkMode: userData.settings.settings.appearance.theme === 'DARK',
+    darkMode: darkModeEnabled,
     connections: getConnections(),
     totalPaymentAmount: getPaymentsTotal(),
   };


### PR DESCRIPTION
Old packages:

- have different names for their channel folders - the `c` prefix was added later it seems
- have the dark mode setting at a different spot in the account file